### PR TITLE
[Autofix][warning] Alert #67: Poorly documented large function

### DIFF
--- a/XEngine_Source/XEngine_ServiceApp/XEngine_HttpApp/XEngine_TaskPost/TaskPost_Image.cpp
+++ b/XEngine_Source/XEngine_ServiceApp/XEngine_HttpApp/XEngine_TaskPost/TaskPost_Image.cpp
@@ -1,5 +1,16 @@
 ﻿#include "../XEngine_Hdr.h"
 
+// 处理图片相关HTTP任务请求。
+// 参数说明：
+// 1) lpszClientAddr: 客户端地址，用于回复与日志。
+// 2) lpszMsgBuffer/nMsgLen: 图片二进制数据及长度（用于设置类操作）。
+// 3) ppptszList/nListCount: HTTP附加参数列表，至少包含操作码及相关参数。
+// 流程说明：
+// - 根据编译开关检查是否支持OpenCV能力；
+// - 解析操作码并分发到不同图片处理分支（获取/设置/扩展操作）；
+// - 对参数数量与格式进行校验；
+// - 调用底层ModuleHelp_ImageSet_*接口处理；
+// - 无论成功或失败，均封包并发送HTTP响应，同时记录日志。
 bool HTTPTask_TaskPost_Image(LPCXSTR lpszClientAddr, LPCXSTR lpszMsgBuffer, int nMsgLen, XCHAR*** ppptszList, int nListCount)
 {
 	int nSDLen = 0;
@@ -8,17 +19,20 @@ bool HTTPTask_TaskPost_Image(LPCXSTR lpszClientAddr, LPCXSTR lpszMsgBuffer, int 
 	CXEngine_MemoryPoolEx m_MemorySend(XENGINE_MEMORY_SIZE_MAX);
 
 #if (0 == _XENGINE_BUILD_SWITCH_OPENCV)
+	// 编译时未启用OpenCV能力：直接返回“不支持”错误。
 	ModuleProtocol_Packet_Common(m_MemorySend.get(), &nSDLen, ERROR_XENGINE_PROTOCL_HTTP_NOTSUPPORT,_X("not support"));
 	XEngine_Network_Send(lpszClientAddr, m_MemorySend.get(), nSDLen);
 	XLOG_PRINT(xhLog, XENGINE_HELPCOMPONENTS_XLOG_IN_LOGLEVEL_ERROR, _X("HTTP客户端:%s,请求图片操作失败,服务器没有启用此功能"), lpszClientAddr);
 	return false;
 #else
 
+	// 从参数列表中提取操作码（示例：opcode=0/1/...）。
 	BaseLib_String_GetKeyValue((*ppptszList)[1], "=", tszHTTPKey, tszHTTPVlu);
 	int nOPCode = _ttxoi(tszHTTPVlu);
-	//0获取,1设置
+	// 0获取,1设置,其它值进入扩展图像处理分支
 	if (0 == nOPCode)
 	{
+		// 获取配置/状态类请求前，先检查服务开关。
 		if (!st_ServiceConfig.st_XImageText.bEnable)
 		{
 			ModuleProtocol_Packet_Common(m_MemorySend.get(), &nSDLen, ERROR_XENGINE_PROTOCL_HTTP_DISABLE, _X("function is disable"));
@@ -62,6 +76,7 @@ bool HTTPTask_TaskPost_Image(LPCXSTR lpszClientAddr, LPCXSTR lpszMsgBuffer, int 
 	}
 	else
 	{
+		// 扩展图片处理分支：要求至少包含操作参数与文件后缀等关键字段。
 		if (nListCount < 4)
 		{
 			ModuleProtocol_Packet_Common(m_MemorySend.get(), &nSDLen, ERROR_XENGINE_PROTOCL_HTTP_FAILURE, _X("image operator failure"));
@@ -69,6 +84,7 @@ bool HTTPTask_TaskPost_Image(LPCXSTR lpszClientAddr, LPCXSTR lpszMsgBuffer, int 
 			XLOG_PRINT(xhLog, XENGINE_HELPCOMPONENTS_XLOG_IN_LOGLEVEL_ERROR, _X("HTTP客户端:%s,请求设置图像数据失败,因为附加参数不正确,参数个数:%d"), lpszClientAddr, nListCount);
 			return false;
 		}
+		// 解析并缓存图片后缀名，供后续压缩/变换接口选择编码器使用。
 		XCHAR tszFileExt[XPATH_MAX];
 		memset(tszFileExt, '\0', sizeof(tszFileExt));
 


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#67](https://github.com/libxengine/XEngine_APIService/security/code-scanning/67) |
| **安全级别** | warning |
| **规则名称** | Poorly documented large function |
| **问题文件** | `XEngine_Source/XEngine_ServiceApp/XEngine_HttpApp/XEngine_TaskPost/TaskPost_Image.cpp` 第 3 行 |
| **CWE 分类** |  |
| **规则标签** | documentation, maintainability, non-attributable, statistical |

---

### 🔍 问题说明

# Poorly documented large function
This rule finds large functions that have too few comment lines. Documentation becomes more important as a function becomes more complex, and a lack of documentation makes it harder to maintain.


## Recommendation
Add comments to document the purpose of the function. Large, complex functions in particular require detailed documentation, not only because they are harder to understand, but the process of documentation may reveal that the function could be split into smaller, more cohesive functions.


## References
* [C++ Programming, Coding style conventions](http://en.wikibooks.org/wiki/C%2B%2B_Programming/Programming_Languages/C%2B%2B/Code/Style_Conventions#Comments)
* [Wikipedia: Need for comments](http://en.wikipedia.org/wiki/Comment_%28computer_progr

---

### 🤖 AI 修复思路

To fix this without changing functionality, add concise but informative comments directly inside `HTTPTask_TaskPost_Image`:

- Add a **function header comment block** describing:
  - purpose of the endpoint handler,
  - expected request structure/parameters at a high level,
  - operation modes (`opcode` routing),
  - return behavior and side effects (network response + logs).
- Add **section comments** before major branches:
  - OpenCV feature-disabled path,
  - opcode parsing/dispatch,
  - each major operation block (get/set/other),
  - argument validation and image extension parsing,
  - success/failure response behavior.
- Keep all logic, control flow, and APIs unchanged.

Only edit:
- `XEngine_Source/XEngine_ServiceApp/XEngine_HttpApp/XEngine_TaskPost/TaskPost_Image.cpp`
- specifically the body area around `HTTPTask_TaskPost_Image` shown in the snippet.

No new methods, no signature changes, no imports/dependencies required.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。