### PR TITLE
[Autofix][high] Alert #49: Incorrect allocation-error handling

### DIFF
--- a/XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp
+++ b/XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp
@@ -298,7 +298,7 @@ bool CModuleConfigure_Json::ModuleConfigure_Json_VersionFile(LPCXSTR lpszConfigF
 		Config_dwErrorCode = ERROR_MODULE_CONFIGURE_JSON_XVER;
 		return false;
 	}
-	pSt_ServerConfig->st_XVer.pStl_ListVer = new list<string>;
+	pSt_ServerConfig->st_XVer.pStl_ListVer = new(std::nothrow) list<string>;
 	if (NULL == pSt_ServerConfig->st_XVer.pStl_ListVer)
 	{
 		Config_IsErrorOccur = true;


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#49](https://github.com/libxengine/XEngine_APIService/security/code-scanning/49) |
| **安全级别** | high |
| **规则名称** | Incorrect allocation-error handling |
| **问题文件** | `XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp` 第 301 行 |
| **CWE 分类** | external/cwe/cwe-252, external/cwe/cwe-570, external/cwe/cwe-755 |
| **规则标签** | correctness, external/cwe/cwe-252, external/cwe/cwe-570, external/cwe/cwe-755, security |

---

### 🔍 问题说明

# Incorrect allocation-error handling
Different overloads of the `new` operator handle allocation failures in different ways. If `new T` fails for some type `T`, it throws a `std::bad_alloc` exception, but `new(std::nothrow) T` returns a null pointer. If the programmer does not use the corresponding method of error handling, allocation failure may go unhandled and could cause the program to behave in unexpected ways.


## Recommendation
Make sure that exceptions are handled appropriately if `new T` is used. On the other hand, make sure to handle the possibility of null pointers if `new(std::nothrow) T` is used.


## Example

```cpp
// BAD: the allocation will throw an unhandled exception
// instead of returning a null pointer.
void bad1(std::size_t length) noexcept {
 int* dest = new int[l

---

### 🤖 AI 修复思路

Use allocation semantics that match the existing local error handling pattern. Since this function already reports failures via error flags and `return false` (instead of exceptions), the best fix is to switch to `new (std::nothrow)` and keep the existing null check.

**What to change (single best minimal fix):**
- In `XEngine_Source/XEngine_ModuleConfigure/ModuleConfigure_Json/ModuleConfigure_Json.cpp`, update line 301 allocation:
  - from `new list<string>`
  - to `new(std::nothrow) list<string>`
- No logic change needed for lines 302–307; that null check then becomes correct and meaningful.
- Ensure `std::nothrow` is available. If not already provided transitively by `pch.h`, add `#include <new>` in this file.

This preserves existing behavior (error code path on allocation failure) without introducing exception-based control flow changes.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。