### PR TITLE
[Autofix][high] Alert #48: Incorrect allocation-error handling

### DIFF
--- a/XEngine_Source/XEngine_ModuleHelp/ModuleHelp_SocketTest/ModuleHelp_SocketTest.cpp
+++ b/XEngine_Source/XEngine_ModuleHelp/ModuleHelp_SocketTest/ModuleHelp_SocketTest.cpp
@@ -58,7 +58,7 @@ bool CModuleHelp_SocketTest::ModuleHelp_SocketTest_StartConnect(XNETHANDLE* pxhT
         ModuleHelp_dwErrorCode = ERROR_XENGINE_APISERVICE_MODULE_HELP_SOCKETTEST_PARAMRT;
         return false;
     }
-    MODULEHELP_SOCKETTEST_CONNINFO* pSt_ConnSocket = new MODULEHELP_SOCKETTEST_CONNINFO;
+    MODULEHELP_SOCKETTEST_CONNINFO* pSt_ConnSocket = new(std::nothrow) MODULEHELP_SOCKETTEST_CONNINFO;
     if (NULL == pSt_ConnSocket)
     {
         ModuleHelp_IsErrorOccur = true;


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#48](https://github.com/libxengine/XEngine_APIService/security/code-scanning/48) |
| **安全级别** | high |
| **规则名称** | Incorrect allocation-error handling |
| **问题文件** | `XEngine_Source/XEngine_ModuleHelp/ModuleHelp_SocketTest/ModuleHelp_SocketTest.cpp` 第 61 行 |
| **CWE 分类** | external/cwe/cwe-252, external/cwe/cwe-570, external/cwe/cwe-755 |
| **规则标签** | correctness, external/cwe/cwe-252, external/cwe/cwe-570, external/cwe/cwe-755, security |

---

### 🔍 问题说明

# Incorrect allocation-error handling
Different overloads of the `new` operator handle allocation failures in different ways. If `new T` fails for some type `T`, it throws a `std::bad_alloc` exception, but `new(std::nothrow) T` returns a null pointer. If the programmer does not use the corresponding method of error handling, allocation failure may go unhandled and could cause the program to behave in unexpected ways.


## Recommendation
Make sure that exceptions are handled appropriately if `new T` is used. On the other hand, make sure to handle the possibility of null pointers if `new(std::nothrow) T` is used.


## Example

```cpp
// BAD: the allocation will throw an unhandled exception
// instead of returning a null pointer.
void bad1(std::size_t length) noexcept {
 int* dest = new int[l

---

### 🤖 AI 修复思路

Use one consistent failure model: either (a) keep throwing `new` and catch `std::bad_alloc`, or (b) switch to `new(std::nothrow)` and keep the null check.  
The least invasive fix here is **switch line 61 to nothrow new** so existing null-check/error-code behavior remains unchanged and no control-flow redesign is needed.

In `XEngine_Source/XEngine_ModuleHelp/ModuleHelp_SocketTest/ModuleHelp_SocketTest.cpp`, update the allocation line inside `ModuleHelp_SocketTest_StartConnect`:

- Change `new MODULEHELP_SOCKETTEST_CONNINFO` to `new(std::nothrow) MODULEHELP_SOCKETTEST_CONNINFO`.
- Keep the existing `NULL == pSt_ConnSocket` check and error-code return path as-is.

No additional methods or structural changes are required. `std::nothrow` is typically available via standard headers already included through `pch.h`; no explicit import change is necessary in the provided snippet.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。