### PR TITLE
[Autofix][high] Alert #45: Incorrect allocation-error handling

### DIFF
--- a/XEngine_Source/XEngine_ModuleHelp/ModuleHelp_Locker/ModuleHelp_Locker.cpp
+++ b/XEngine_Source/XEngine_ModuleHelp/ModuleHelp_Locker/ModuleHelp_Locker.cpp
@@ -34,8 +34,8 @@ CModuleHelp_Locker::~CModuleHelp_Locker()
   意思：是否成功
 备注：
 *********************************************************************/
-bool CModuleHelp_Locker::ModuleHelp_Locker_Create(XNETHANDLE* pxhToken)
-{
+	bool CModuleHelp_Locker::ModuleHelp_Locker_Create(XNETHANDLE* pxhToken)
+	{
 	ModuleHelp_IsErrorOccur = false;
 
 	if (NULL == pxhToken)
@@ -44,7 +44,7 @@ bool CModuleHelp_Locker::ModuleHelp_Locker_Create(XNETHANDLE* pxhToken)
 		ModuleHelp_dwErrorCode = ERROR_XENGINE_APISERVICE_MODULE_HELP_LOCK_PARAMENT;
 		return false;
 	}
-	MODULEHELP_LOCKINFO *pSt_LockInfo = new MODULEHELP_LOCKINFO;
+	MODULEHELP_LOCKINFO *pSt_LockInfo = new(std::nothrow) MODULEHELP_LOCKINFO;
 	if (NULL == pSt_LockInfo)
 	{
 		ModuleHelp_IsErrorOccur = true;
@@ -73,8 +73,8 @@ bool CModuleHelp_Locker::ModuleHelp_Locker_Create(XNETHANDLE* pxhToken)
   意思：是否成功
 备注：
 *********************************************************************/
-bool CModuleHelp_Locker::ModuleHelp_Locker_OPen(XNETHANDLE xhToken)
-{
+	bool CModuleHelp_Locker::ModuleHelp_Locker_OPen(XNETHANDLE xhToken)
+	{
 	ModuleHelp_IsErrorOccur = false;
 
 	//看看存在不存在
@@ -89,7 +89,7 @@ bool CModuleHelp_Locker::ModuleHelp_Locker_OPen(XNETHANDLE xhToken)
 	}
 	st_Locker.unlock_shared();
 	//不存在插入
-	MODULEHELP_LOCKINFO* pSt_LockInfo = new MODULEHELP_LOCKINFO;
+	MODULEHELP_LOCKINFO* pSt_LockInfo = new(std::nothrow) MODULEHELP_LOCKINFO;
 	if (NULL == pSt_LockInfo)
 	{
 		ModuleHelp_IsErrorOccur = true;


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#45](https://github.com/libxengine/XEngine_APIService/security/code-scanning/45) |
| **安全级别** | high |
| **规则名称** | Incorrect allocation-error handling |
| **问题文件** | `XEngine_Source/XEngine_ModuleHelp/ModuleHelp_Locker/ModuleHelp_Locker.cpp` 第 92 行 |
| **CWE 分类** | external/cwe/cwe-252, external/cwe/cwe-570, external/cwe/cwe-755 |
| **规则标签** | correctness, external/cwe/cwe-252, external/cwe/cwe-570, external/cwe/cwe-755, security |

---

### 🔍 问题说明

# Incorrect allocation-error handling
Different overloads of the `new` operator handle allocation failures in different ways. If `new T` fails for some type `T`, it throws a `std::bad_alloc` exception, but `new(std::nothrow) T` returns a null pointer. If the programmer does not use the corresponding method of error handling, allocation failure may go unhandled and could cause the program to behave in unexpected ways.


## Recommendation
Make sure that exceptions are handled appropriately if `new T` is used. On the other hand, make sure to handle the possibility of null pointers if `new(std::nothrow) T` is used.


## Example

```cpp
// BAD: the allocation will throw an unhandled exception
// instead of returning a null pointer.
void bad1(std::size_t length) noexcept {
 int* dest = new int[l

---

### 🤖 AI 修复思路

通用修复原则：  
- 若要用空指针分支处理分配失败，就必须使用 `new(std::nothrow)`；  
- 若继续使用普通 `new`，就应使用 `try/catch(std::bad_alloc&)` 处理。  

在这段代码中，最佳且最小变更方案是：把两处分配都改为 `new(std::nothrow) MODULEHELP_LOCKINFO`，保留现有 `NULL` 检查和错误码返回逻辑，不改变函数接口和行为风格（返回 `bool` + 错误码）。

需要修改的区域（同一文件）：
- `ModuleHelp_Locker_Create` 中 `new MODULEHELP_LOCKINFO`（第47行附近）
- `ModuleHelp_Locker_OPen` 中 `new MODULEHELP_LOCKINFO`（第92行附近）

实现所需内容：
- 使用 `std::nothrow`（通常由已有公共头包含；若项目未间接包含，需 `<new>`，但当前按“仅改已给片段、最小改动”先不新增 include）。

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。