### PR TITLE
[Autofix][critical] Alert #58: Potentially overrunning write

### DIFF
--- a/XEngine_Source/XEngine_PluginModule/ModulePlugin_Timezone/Plugin_Timezone/Plugin_Timezone.cpp
+++ b/XEngine_Source/XEngine_PluginModule/ModulePlugin_Timezone/Plugin_Timezone/Plugin_Timezone.cpp
@@ -704,7 +704,7 @@ bool CPlugin_Timezone::Plugin_Timezone_Convert(LPCXSTR lpszConvert, LPCXSTR lpsz
 
 	_stxscanf(lpszTimeStr, _X("%04d-%02d-%02d_%02d:%02d:%02d"), &st_TimeStart.wYear, &st_TimeStart.wMonth, &st_TimeStart.wDay, &st_TimeStart.wHour, &st_TimeStart.wMinute, &st_TimeStart.wSecond);
 	BaseLib_TimeSpan_CalForStu(&st_TimeStart, &st_TimeEnd);
-	_xstprintf(tszTimeStr, _X("%04d-%02d-%02d %02d:%02d:%02d"), st_TimeEnd.wYear, st_TimeEnd.wMonth, st_TimeEnd.wDay, st_TimeEnd.wHour, st_TimeEnd.wMinute, st_TimeEnd.wSecond);
+	_xstprintf_s(tszTimeStr, sizeof(tszTimeStr) / sizeof(tszTimeStr[0]), _X("%04d-%02d-%02d %02d:%02d:%02d"), st_TimeEnd.wYear, st_TimeEnd.wMonth, st_TimeEnd.wDay, st_TimeEnd.wHour, st_TimeEnd.wMinute, st_TimeEnd.wSecond);
 
 	st_JsonObject["tszTimeStr"] = tszTimeStr;
 	st_JsonObject["tszTimeZone"] = stl_MapIterator->first.c_str();


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#58](https://github.com/libxengine/XEngine_APIService/security/code-scanning/58) |
| **安全级别** | critical |
| **规则名称** | Potentially overrunning write |
| **问题文件** | `XEngine_Source/XEngine_PluginModule/ModulePlugin_Timezone/Plugin_Timezone/Plugin_Timezone.cpp` 第 707 行 |
| **CWE 分类** | external/cwe/cwe-120, external/cwe/cwe-787, external/cwe/cwe-805 |
| **规则标签** | external/cwe/cwe-120, external/cwe/cwe-787, external/cwe/cwe-805, reliability, security |

---

### 🔍 问题说明

# Potentially overrunning write
The program performs a buffer copy or write operation with no upper limit on the size of the copy, and it appears that certain inputs will cause a buffer overflow to occur in this case. In addition to causing program instability, techniques exist which may allow an attacker to use this vulnerability to execute arbitrary code.


## Recommendation
Always control the length of buffer copy and buffer write operations. `strncpy` should be used over `strcpy`, `snprintf` over `sprintf`, and in other cases 'n-variant' functions should be preferred.


## Example

```c
void sayHello(uint32_t userId)
{
	char buffer[18];

	// BAD: this message overflows the buffer if userId >= 10000
	sprintf(buffer, "Hello, user %d!", userId);

	MessageBox(hWnd, buffer, "New Message", M

---

### 🤖 AI 修复思路

Use a bounded formatting function for `tszTimeStr` so writes cannot exceed the 64-byte buffer.

Best fix in this snippet:
- In `XEngine_Source/XEngine_PluginModule/ModulePlugin_Timezone/Plugin_Timezone/Plugin_Timezone.cpp`, replace `_xstprintf(...)` with `_xstprintf_s(...)` and pass the destination buffer size (`sizeof(tszTimeStr) / sizeof(tszTimeStr[0])`).
- This preserves current output format and behavior while enforcing a hard limit.
- No new methods or dependencies are required. No import changes are needed.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。